### PR TITLE
feat(datetime,period): typed units, truncate/round/clamp/between; typed RangeByUnit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Week-of-month helpers: `WeekOfMonthISO()` and `WeekOfMonthWithStart(start)`
 - GitHub Actions CI matrix across OS and Go versions; coverage artifact upload
 - Makefile with common developer tasks
+- Rounding and range utilities: `Truncate(unit)`, `Round(unit)`, `Clamp(min,max)`, `Between(a,b,inclusive)`; typed iteration `RangeByUnit(unit, step...)`
+- Parsing: `ParseStrict`, `ParseStrictInLocation`, and ISO 8601 duration parsing via `ParseISODuration`
 
 ### Changed
 - `IsDST()` now determines standard offset via minimum offset observed in the year for the location (robust across hemispheres)
 - README updates: CI badge, Go Reference badge, Unix helpers, serialization/DB docs, examples section, Makefile usage
+ - README docs for rounding/range utilities and DST notes
+ - README docs for strict parsing and ISO 8601 duration parsing
 
 ### Fixed
 - Repository hygiene: added `.gitignore` for binaries/coverage; removed committed demo binary

--- a/bench_test.go
+++ b/bench_test.go
@@ -22,3 +22,31 @@ func BenchmarkDiffForHumans(b *testing.B) {
 		_ = other.DiffForHumans(base)
 	}
 }
+
+func BenchmarkIsDST(b *testing.B) {
+	ny, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		b.Skip("NY tz not available")
+	}
+	summer := Date(2023, time.July, 15, 12, 0, 0, 0, ny)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = summer.IsDST()
+	}
+}
+
+func BenchmarkPeriodRangeByUnitDays(b *testing.B) {
+	start := Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	end := Date(2023, time.December, 31, 0, 0, 0, 0, time.UTC)
+	p := NewPeriod(start, end)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		count := 0
+		for range p.RangeByUnit(UnitDay, 7) { // weekly steps
+			count++
+		}
+		if count == 0 {
+			b.Fatal("unexpected zero count")
+		}
+	}
+}

--- a/period_test.go
+++ b/period_test.go
@@ -387,3 +387,30 @@ func TestPeriodRangeWithContext(t *testing.T) {
 		}
 	})
 }
+
+// Quick wins tests: typed iteration helper
+func TestPeriodRangeByUnit(t *testing.T) {
+	loc := time.UTC
+	start := Date(2023, time.January, 1, 0, 0, 0, 0, loc)
+	end := Date(2023, time.January, 10, 0, 0, 0, 0, loc)
+	p := NewPeriod(start, end)
+
+	// Every 3 days
+	cnt := 0
+	prev := start
+	for d := range p.RangeByUnit(UnitDay, 3) {
+		if cnt == 0 && !d.Equal(start) {
+			t.Fatalf("First day should be start, got %v", d)
+		}
+		if cnt > 0 {
+			if diff := d.Sub(prev); diff != 72*time.Hour { // 3 days
+				t.Fatalf("Step mismatch: got %v", diff)
+			}
+		}
+		prev = d
+		cnt++
+	}
+	if cnt == 0 {
+		t.Fatalf("Expected at least one iteration")
+	}
+}


### PR DESCRIPTION
Adds typed Unit enum; DateTime helpers (Truncate, Round, Clamp, Between); typed Period.RangeByUnit; docs and benches. Tests merged into existing files.